### PR TITLE
snap: add support for riscv64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,10 +12,9 @@ architectures:
   - build-on: arm64
   - build-on: amd64
 
-
 apps:
   ui-app:
-    command: bin/npm run dev
+    command: usr/bin/npm run dev
   ui-service:
     command: bin/http-server $SNAP/static -p 4000 --cors
     daemon: simple
@@ -31,10 +30,14 @@ apps:
       - snapd-control
 
 parts:
+  npm-deps:
+    plugin: nil
+    stage-snaps:
+      - nodejs-binaries
+
   ui:
     plugin: npm
-    npm-include-node: true
-    npm-node-version: 16.15.0
+    after: [npm-deps]
     source: app
     build-packages:
       - build-essential
@@ -49,8 +52,7 @@ parts:
 
   http-server:
     plugin: npm
-    npm-include-node: true
-    npm-node-version: 16.15.0
+    after: [npm-deps]
     source: https://github.com/http-party/http-server.git
     source-tag: v14.1.0
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,10 +8,6 @@ description: |
 grade: stable
 confinement: strict
 
-architectures:
-  - build-on: arm64
-  - build-on: amd64
-
 apps:
   ui-app:
     command: usr/bin/npm run dev


### PR DESCRIPTION
As there are no precompiled binaries available for riscv64, we need to build NodeJS and NPM from sources. This change adds a new npm-deps part, which retains the previous behaviour on non-riscv64 platforms (i.e. it fetches the binary archive from nodejs.org), but fetches and compiles the sources when building on riscv64.